### PR TITLE
Fix example in documentation

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -78,9 +78,9 @@ output {
     json_key_file => "service_account_key.json"
 
     # Options for configuring the upload
-    message_count_threshold => 10000
+    message_count_threshold => 1000
     delay_threshold_secs => 10
-    request_byte_threshold => 5MB
+    request_byte_threshold => 5000000
   }
 }
 ------------------------------------------------------------------------------
@@ -209,7 +209,7 @@ A value of 0 will cause messages to instantly be sent but will reduce total thro
 ===== `request_byte_threshold`
 
   * Value type is <<bytes,bytes>>
-  * Default is: `1_000_000`
+  * Default is: `1000000`
 
 Once the number of bytes in the batched request reaches this threshold, send all of the messages in
 a single call, even if neither the delay or message count thresholds have been exceeded yet.


### PR DESCRIPTION
In the docs, the example for high volume is 

```output {
  google_pubsub {
    project_id => "my_project"
    topic => "my_topic"
    json_key_file => "service_account_key.json"

    # Options for configuring the upload
    message_count_threshold => 10000
    delay_threshold_secs => 10
    request_byte_threshold => 5MB
  }
}
```

But the docs say the max  `message_count_threshold` is 1000. (https://github.com/googleapis/google-cloud-java/blob/dc2672ad1838a8d15a66e1f1697c97c84e4e0933/google-cloud-clients/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java#L113). So let's fix this example.

Also, `5MB` isn't a valid value and `request_byte_threshold` expects an integer. So, fix this in the example as well as the docs where it shows the default. (I made the mistake of keeping the underscores in the integer since it's valid in Ruby).

This should also address https://github.com/logstash-plugins/logstash-output-google_pubsub/issues/16